### PR TITLE
Increase voice playback speed for Edge TTS

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -63,7 +63,7 @@ class Config:
 
     # ── TTS Settings ──
     TTS_VOICE: str = os.getenv("TTS_VOICE", "en-IN-PrabhatNeural")
-    TTS_RATE: str = os.getenv("TTS_RATE", "+0%")
+    TTS_RATE: str = os.getenv("TTS_RATE", "+10%")
     TTS_PITCH: str = os.getenv("TTS_PITCH", "+0Hz")
 
     # ── AI Models ──

--- a/backend/modules/tts.py
+++ b/backend/modules/tts.py
@@ -28,7 +28,12 @@ async def generate_tts(text: str, voice: str = "", output_path: str = "") -> str
         tmp.close()
 
     try:
-        tts = edge_tts.Communicate(text=text, voice=voice)
+        tts = edge_tts.Communicate(
+            text=text,
+            voice=voice,
+            rate=config.TTS_RATE,
+            pitch=config.TTS_PITCH,
+        )
         await tts.save(output_path)
         return output_path
     except Exception as e:


### PR DESCRIPTION
### Motivation
- Make the AI voice slightly faster by ensuring runtime TTS rate/pitch settings are applied and adjusting the default rate.

### Description
- Wire `config.TTS_RATE` and `config.TTS_PITCH` into `edge_tts.Communicate` and update the default `TTS_RATE` from `+0%` to `+10%` by changing `backend/modules/tts.py` and `backend/config.py`.

### Testing
- Ran `python -m compileall backend/modules/tts.py backend/config.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8cba32994832399e5ab6580755251)