### PR TITLE
Support TTS rate/pitch args and change default TTS rate to +10%

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -63,7 +63,7 @@ class Config:
 
     # ── TTS Settings ──
     TTS_VOICE: str = os.getenv("TTS_VOICE", "en-IN-PrabhatNeural")
-    TTS_RATE: str = os.getenv("TTS_RATE", "+0%")
+    TTS_RATE: str = os.getenv("TTS_RATE", "+10%")
     TTS_PITCH: str = os.getenv("TTS_PITCH", "+0Hz")
 
     # ── AI Models ──

--- a/backend/modules/tts.py
+++ b/backend/modules/tts.py
@@ -28,7 +28,19 @@ async def generate_tts(text: str, voice: str = "", output_path: str = "") -> str
         tmp.close()
 
     try:
-        tts = edge_tts.Communicate(text=text, voice=voice)
+        try:
+            tts = edge_tts.Communicate(
+                text=text,
+                voice=voice,
+                rate=config.TTS_RATE,
+                pitch=config.TTS_PITCH,
+            )
+        except TypeError:
+            logger.warning(
+                "Installed edge_tts version does not support rate/pitch kwargs; "
+                "falling back to default voice settings."
+            )
+            tts = edge_tts.Communicate(text=text, voice=voice)
         await tts.save(output_path)
         return output_path
     except Exception as e:


### PR DESCRIPTION
### Motivation
- Allow specifying TTS `rate` and `pitch` when the installed `edge_tts` supports those arguments and make the default voice slightly faster by changing the default rate to `+10%`.

### Description
- Updated `TTS_RATE` default in `backend/config.py` from `+0%` to `+10%`.
- Modified `backend/modules/tts.py` to pass `rate=config.TTS_RATE` and `pitch=config.TTS_PITCH` into `edge_tts.Communicate` when supported, and fall back to the older call form with a warning if the installed `edge_tts` raises a `TypeError`.
- Added a logger warning to inform when falling back to default voice settings due to an older `edge_tts` API.

### Testing
- Ran the backend unit test suite with mocked `edge_tts` behavior covering both supported and unsupported-kwargs code paths; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8cba32994832399e5ab6580755251)