### PR TITLE
Fix open-app fallback, shorten greetings, and left-align skill chips

### DIFF
--- a/backend/agent_core.py
+++ b/backend/agent_core.py
@@ -5,6 +5,7 @@ Added: Personality evolution, fact extraction, friendly tone.
 """
 import asyncio
 import logging
+import re
 from typing import Dict, Any, Optional
 from config import config
 from modules.llm import get_response, get_response_with_skill_result, get_greeting
@@ -13,6 +14,22 @@ from modules.memory import get_memory_manager
 from modules.tts import generate_tts
 
 logger = logging.getLogger("JARVIS.AGENT")
+
+
+def _force_open_app_skill(text: str) -> Optional[str]:
+    """Deterministic fallback for open-app requests when LLM misses skill tag."""
+    patterns = [
+        r"(?:\bopen\b|\bkhol(?:o|na|do)?\b|\blaunch\b)\s+([a-zA-Z0-9 ._+-]{2,40})",
+        r"([a-zA-Z0-9 ._+-]{2,40})\s+(?:open\s+kar(?:o)?|khol(?:o|na|do)?\s+|launch\s+kar(?:o)?)",
+    ]
+    clean = text.strip().lower()
+    for pat in patterns:
+        m = re.search(pat, clean, re.IGNORECASE)
+        if m:
+            app_name = m.group(1).strip(" .,!?")
+            if app_name:
+                return f"[SKILL:open_app:{app_name}]"
+    return None
 
 
 class JarvisAgent:
@@ -44,6 +61,8 @@ class JarvisAgent:
             result = await get_response(text, memory_context)
             llm_response = result["response"]
             skill_tag = result.get("skill")
+            if not skill_tag:
+                skill_tag = _force_open_app_skill(text)
 
             if skill_tag:
                 # Execute skill

--- a/backend/modules/llm.py
+++ b/backend/modules/llm.py
@@ -174,7 +174,7 @@ CONTEXT: {memory_context}
 
 GREETING_PROMPT = """You are JARVIS, Sanket's personal AI assistant — a smart, friendly buddy.
 
-Generate ONE warm, personal greeting in Hinglish. Max 2 sentences.
+Generate ONE short greeting in Hinglish. Max 1 sentence, ideally 8-14 words.
 Feel like a real friend who knows him — not a generic bot.
 Mention time of day. Ask what he's working on or planning.
 No markdown. Plain speech only. No "sir" — use "bhai", "yaar", or direct name.
@@ -228,7 +228,7 @@ async def get_greeting() -> str:
                     {"role": "user", "content": GREETING_PROMPT.replace("{time_context}", time_context)}
                 ],
                 temperature=0.9,
-                max_tokens=80,
+                max_tokens=30,
             )
 
         response = await asyncio.wait_for(_execute_with_retry(make_call), timeout=15.0)

--- a/frontend/src/components/SkillChips.jsx
+++ b/frontend/src/components/SkillChips.jsx
@@ -22,13 +22,13 @@ export default function SkillChips({ onSkillSelect, disabled = false, chatOpen =
       style={{
         position: 'fixed',
         bottom: '1.5rem',
-        left: chatOpen ? 'calc(50% - 190px)' : '50%',
-        transform: 'translateX(-50%)',
+        left: chatOpen ? '1.5rem' : '50%',
+        transform: chatOpen ? 'none' : 'translateX(-50%)',
         transition: 'left 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
         display: 'flex',
         gap: '0.5rem',
         flexWrap: 'wrap',
-        justifyContent: 'center',
+        justifyContent: chatOpen ? 'flex-start' : 'center',
         maxWidth: '600px',
         zIndex: 20,
       }}


### PR DESCRIPTION
### Motivation
- Ensure user requests to open/launch apps actually trigger the open-app skill when the LLM fails to emit a skill tag.  
- Reduce overly long greeting speech and enforce a concise greeting format.  
- Prevent quick-skill chips from overlapping the chat input by left-aligning them when chat is open.

### Description
- Added a deterministic fallback `_force_open_app_skill` in `backend/agent_core.py` that detects patterns like "open/khol/launch <app>" and forces a `[SKILL:open_app:<name>]` tag when the LLM omits it, and integrated it into `process_text_input`.  
- Tightened the greeting behavior in `backend/modules/llm.py` by updating `GREETING_PROMPT` to request a single short sentence and lowering the greeting LLM call `max_tokens` from `80` to `30`.  
- Adjusted layout in `frontend/src/components/SkillChips.jsx` so the skill chips use `left: 1.5rem` and `justifyContent: flex-start` when `chatOpen` is true, and only center/translate when chat is closed to avoid overlap.  
- No behavior changes to other skill execution code; changes are minimal and localized to the three files above.

### Testing
- Ran Python compilation: `python -m compileall backend/agent_core.py backend/modules/llm.py` which succeeded.  
- Built frontend: `cd frontend && npm run build` which completed successfully (Vite produced a non-blocking large chunk warning but build artifacts were generated).  
- No unit tests were added in this PR; recommend adding automated tests for `_force_open_app_skill` regex coverage in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff34b856148323b34082070a4ea58e)